### PR TITLE
Fix login redirect loop caused by SECURITY-901 changes in Jenkins core

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/cas/CasSecurityRealm.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/cas/CasSecurityRealm.groovy
@@ -87,6 +87,7 @@ casFilter(ChainedServletFilter) {
 			serviceProperties = casServiceProperties
 			authenticationFailureHandler = bean(SimpleUrlAuthenticationFailureHandler, "/" + securityRealm.failedLoginUrl)
 			authenticationSuccessHandler = bean(SessionUrlAuthenticationSuccessHandler, "/")
+			continueChainBeforeSuccessfulAuthentication = true
 		}
 	]
 }


### PR DESCRIPTION
As described in fcrespel/jenkins-cas-plugin#9, Jenkins 2.160 and 2.150.2 LTS introduced changes to fix [SECURITY-901](https://jenkins.io/security/advisory/2019-01-16/#SECURITY-901) issues, which [broke the CAS plugin (and others)](https://wiki.jenkins.io/display/JENKINS/Plugins+affected+by+the+SECURITY-901+fix) with an infinite redirect loop.

This PR changes the login flow to handle the Acegi SecurityContext mapping and call `SecurityListener.fireAuthenticated()` in `doFinishLogin()`, so that the user seed is properly stored in session.