### PR TITLE
Upgrade to Spring Security 6.x and EE 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- Upgrade to Spring Security 6.x and Jakarta EE 9 (thanks to [@basil](https://github.com/basil)).
+- Compatibility with Jenkins 2.476 and higher (requires Java 17).
+- Incompatibility with Jenkins 2.475 and lower, please make sure to upgrade CAS plugin and Jenkins together.
+
 ## [1.6.3] - 2023-05-14
 
 - Fixed security issue (SECURITY-3000).

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,4 @@
-buildPlugin()
+buildPlugin(useContainerAgent: true, configurations: [
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
+])

--- a/README.md
+++ b/README.md
@@ -13,9 +13,16 @@ The latest version is available for download from the Update Center and from the
 
 ### Upgrade notice
 
-- Jenkins **2.266 and higher** require CAS plugin version **1.5.0** or higher.
-- Jenkins **2.265 and lower** require CAS plugin version **1.4.3** (1.5.0 is _NOT_ compatible).
-- Jenkins **2.160 or 2.150.2 LTS** and higher require CAS plugin version **1.4.3**.
+Some Jenkins versions require specific CAS plugin versions for compatibility reasons:
+
+| Jenkins version    | CAS plugin version |
+|--------------------|--------------------|
+| 2.476 and higher   | 1.7.0 and higher   |
+| 2.475              | not compatible     |
+| 2.266 to 2.474     | 1.5.0 to 1.6.3     |
+| 2.160 to 2.265     | 1.4.3              |
+| 2.150.2 to 2.150.3 | 1.4.3              |
+| Older releases     | 1.4.2 and lower    |
 
 In these cases, you will need to upgrade Jenkins and CAS plugin together to avoid issues. This means manually downloading and updating the `cas-plugin.hpi` file in your Jenkins `plugins` directory (rename to `cas-plugin.jpi` as needed).
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,40 +90,42 @@ THE SOFTWARE.
 		<revision>1.6.4</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
-		<jenkins.version>2.440.3</jenkins.version>
-		<cas-client.version>3.6.4</cas-client.version>
+		<!-- TODO https://github.com/jenkinsci/jenkins/pull/9696 -->
+		<jenkins.version>2.476-rc35309.670fcb_f703b_7</jenkins.version>
+		<!-- TODO JENKINS-73339 until in parent POM -->
+		<jenkins-test-harness.version>2265.v3da_49c8134d6</jenkins-test-harness.version>
+		<maven.compiler.release>17</maven.compiler.release>
+		<cas-client.version>4.0.4</cas-client.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.440.x</artifactId>
+				<artifactId>bom-2.462.x</artifactId>
 				<version>3334.v18e2a_2f48356</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
 			<dependency>
-				<groupId>org.jasig.cas.client</groupId>
+				<groupId>org.apereo.cas.client</groupId>
 				<artifactId>cas-client-core</artifactId>
 				<version>${cas-client.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jasig.cas.client</groupId>
+				<groupId>org.apereo.cas.client</groupId>
 				<artifactId>cas-client-support-saml</artifactId>
 				<version>${cas-client.version}</version>
+			</dependency>
+			<!-- TODO JENKINS-73339 until in parent POM, work around https://github.com/jenkinsci/plugin-pom/issues/936 -->
+			<dependency>
+				<groupId>jakarta.servlet</groupId>
+				<artifactId>jakarta.servlet-api</artifactId>
+				<version>5.0.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>
-		<dependency>
-			<groupId>io.jenkins.plugins</groupId>
-			<artifactId>jaxb</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.jenkins.plugins</groupId>
-			<artifactId>joda-time-api</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>bouncycastle-api</artifactId>
@@ -141,7 +143,7 @@ THE SOFTWARE.
 			<artifactId>script-security</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jasig.cas.client</groupId>
+			<groupId>org.apereo.cas.client</groupId>
 			<artifactId>cas-client-support-saml</artifactId>
 			<exclusions>
 				<!-- Provided by jackson2-api plugin -->
@@ -159,13 +161,12 @@ THE SOFTWARE.
 				</exclusion>
 				<!-- Provided by Jenkins core -->
 				<exclusion>
+					<groupId>com.github.stephenc.jcip</groupId>
+					<artifactId>jcip-annotations</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>commons-codec</groupId>
 					<artifactId>commons-codec</artifactId>
-				</exclusion>
-				<!-- Provided by joda-time-api plugin -->
-				<exclusion>
-					<groupId>joda-time</groupId>
-					<artifactId>joda-time</artifactId>
 				</exclusion>
 				<!-- Provided by bouncycastle-api plugin -->
 				<exclusion>
@@ -175,11 +176,6 @@ THE SOFTWARE.
 				<exclusion>
 					<groupId>org.bouncycastle</groupId>
 					<artifactId>bcprov-jdk15on</artifactId>
-				</exclusion>
-				<!-- Provided by jaxb plugin -->
-				<exclusion>
-					<groupId>org.glassfish.jaxb</groupId>
-					<artifactId>jaxb-core</artifactId>
 				</exclusion>
 				<!-- Provided by Jenkins core -->
 				<exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 The MIT License
 
@@ -28,7 +29,7 @@ THE SOFTWARE.
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.12</version>
+		<version>4.87</version>
 		<relativePath />
 	</parent>
 
@@ -36,11 +37,11 @@ THE SOFTWARE.
 	<version>${revision}${changelist}</version>
 	<packaging>hpi</packaging>
 	<name>CAS Plugin</name>
-	<url>https://github.com/jenkinsci/cas-plugin</url>
+	<url>https://github.com/jenkinsci/${project.artifactId}</url>
 
 	<scm>
-		<connection>scm:git:ssh://github.com/${gitHubRepo}.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
+		<connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+		<developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
 		<url>https://github.com/${gitHubRepo}</url>
 		<tag>${scmTag}</tag>
 	</scm>
@@ -67,8 +68,8 @@ THE SOFTWARE.
 
 	<licenses>
 		<license>
-			<name>The MIT License</name>
-			<url>http://www.opensource.org/licenses/MIT</url>
+			<name>MIT License</name>
+			<url>https://opensource.org/license/mit/</url>
 		</license>
 	</licenses>
 
@@ -88,32 +89,19 @@ THE SOFTWARE.
 	<properties>
 		<revision>1.6.4</revision>
 		<changelist>-SNAPSHOT</changelist>
-		<gitHubRepo>jenkinsci/cas-plugin</gitHubRepo>
-		<java.level>8</java.level>
-		<jenkins.version>2.266</jenkins.version>
-		<cas-client.version>3.6.1</cas-client.version>
-		<bouncycastle-api.version>2.18</bouncycastle-api.version>
-		<jaxb.version>2.3.6-1</jaxb.version>
+		<gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
+		<jenkins.version>2.440.3</jenkins.version>
+		<cas-client.version>3.6.4</cas-client.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.263.x</artifactId>
-				<version>18</version>
+				<artifactId>bom-2.440.x</artifactId>
+				<version>3334.v18e2a_2f48356</version>
 				<scope>import</scope>
 				<type>pom</type>
-			</dependency>
-			<dependency>
-				<groupId>org.jenkins-ci.plugins</groupId>
-				<artifactId>bouncycastle-api</artifactId>
-				<version>${bouncycastle-api.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>io.jenkins.plugins</groupId>
-				<artifactId>jaxb</artifactId>
-				<version>${jaxb.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jasig.cas.client</groupId>
@@ -129,12 +117,20 @@ THE SOFTWARE.
 	</dependencyManagement>
 	<dependencies>
 		<dependency>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>jaxb</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>joda-time-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>bouncycastle-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>io.jenkins.plugins</groupId>
-			<artifactId>jaxb</artifactId>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>jackson2-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
@@ -147,6 +143,50 @@ THE SOFTWARE.
 		<dependency>
 			<groupId>org.jasig.cas.client</groupId>
 			<artifactId>cas-client-support-saml</artifactId>
+			<exclusions>
+				<!-- Provided by jackson2-api plugin -->
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+				<!-- Provided by Jenkins core -->
+				<exclusion>
+					<groupId>commons-codec</groupId>
+					<artifactId>commons-codec</artifactId>
+				</exclusion>
+				<!-- Provided by joda-time-api plugin -->
+				<exclusion>
+					<groupId>joda-time</groupId>
+					<artifactId>joda-time</artifactId>
+				</exclusion>
+				<!-- Provided by bouncycastle-api plugin -->
+				<exclusion>
+					<groupId>org.bouncycastle</groupId>
+					<artifactId>bcpkix-jdk15on</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.bouncycastle</groupId>
+					<artifactId>bcprov-jdk15on</artifactId>
+				</exclusion>
+				<!-- Provided by jaxb plugin -->
+				<exclusion>
+					<groupId>org.glassfish.jaxb</groupId>
+					<artifactId>jaxb-core</artifactId>
+				</exclusion>
+				<!-- Provided by Jenkins core -->
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,7 @@ THE SOFTWARE.
 		<revision>1.6.4</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
-		<!-- TODO https://github.com/jenkinsci/jenkins/pull/9696 -->
-		<jenkins.version>2.476-rc35309.670fcb_f703b_7</jenkins.version>
+		<jenkins.version>2.476</jenkins.version>
 		<!-- TODO JENKINS-73339 until in parent POM -->
 		<jenkins-test-harness.version>2265.v3da_49c8134d6</jenkins-test-harness.version>
 		<maven.compiler.release>17</maven.compiler.release>

--- a/src/main/java/org/jenkinsci/plugins/cas/CasProtocol.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/CasProtocol.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.jasig.cas.client.validation.TicketValidator;
+import org.apereo.cas.client.validation.TicketValidator;
 import org.springframework.security.cas.ServiceProperties;
 
 import hudson.DescriptorExtensionList;

--- a/src/main/java/org/jenkinsci/plugins/cas/CasSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/CasSecurityRealm.java
@@ -6,21 +6,21 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 
 import org.apache.commons.lang.StringUtils;
-import org.jasig.cas.client.session.SessionMappingStorage;
-import org.jasig.cas.client.util.CommonUtils;
+import org.apereo.cas.client.session.SessionMappingStorage;
+import org.apereo.cas.client.util.CommonUtils;
 import org.jenkinsci.plugins.cas.spring.CasConfigurationContext;
 import org.jenkinsci.plugins.cas.spring.security.CasRestAuthenticator;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +41,7 @@ import org.springframework.security.web.util.UrlUtils;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Descriptor;
-import hudson.security.ChainedServletFilter;
+import hudson.security.ChainedServletFilter2;
 import hudson.security.SecurityRealm;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
@@ -168,7 +168,7 @@ public class CasSecurityRealm extends SecurityRealm {
 	// ~ SecurityRealm implementation ===================================================================================
 
 	/**
-	 * Login begins with our {@link #doCommenceLogin(StaplerRequest, StaplerResponse)} method.
+	 * Login begins with our {@link #doCommenceLogin(StaplerRequest2, StaplerResponse2)} method.
 	 * @return Jenkins commenceLogin URL
 	 */
 	@Override
@@ -181,7 +181,7 @@ public class CasSecurityRealm extends SecurityRealm {
 	 * @return CAS logout URL
 	 */
 	@Override
-	protected String getPostLogOutUrl2(StaplerRequest req, Authentication auth) {
+	protected String getPostLogOutUrl2(StaplerRequest2 req, Authentication auth) {
 		if (Boolean.TRUE.equals(this.enableLogoutRedirect)) {
 			StringBuilder logoutUrlBuilder = new StringBuilder(casServerUrl);
 			logoutUrlBuilder.append("logout?service=");
@@ -227,8 +227,8 @@ public class CasSecurityRealm extends SecurityRealm {
 	public Filter createFilter(FilterConfig filterConfig) {
 		LOG.debug("Creating CAS authentication filter");
 		Filter defaultFilter = super.createFilter(filterConfig);
-		Filter casFilter = getApplicationContext().getBean("casFilter", ChainedServletFilter.class);
-		return new ChainedServletFilter(casFilter, defaultFilter);
+		Filter casFilter = getApplicationContext().getBean("casFilter", ChainedServletFilter2.class);
+		return new ChainedServletFilter2(casFilter, defaultFilter);
 	}
 
 	// ~ Stapler controller actions =====================================================================================
@@ -241,7 +241,7 @@ public class CasSecurityRealm extends SecurityRealm {
 	 * @throws ServletException Servlet error
 	 */
 	@Override
-	public void doLogout(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+	public void doLogout(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
 		// Remove session from CAS single sign-out storage
 		HttpSession session = req.getSession(false);
 		if (session != null) {
@@ -257,7 +257,7 @@ public class CasSecurityRealm extends SecurityRealm {
 	 * @throws IOException I/O error
 	 * @throws ServletException Servlet error
 	 */
-	public void doCommenceLogin(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+	public void doCommenceLogin(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
 		LOG.debug("Redirecting to CAS for authentication");
 		getApplicationContext().getBean(CasAuthenticationEntryPoint.class).commence(req, rsp, null);
 	}
@@ -267,7 +267,7 @@ public class CasSecurityRealm extends SecurityRealm {
 	 * @param req request
 	 * @param rsp response
 	 */
-	public void doFinishLogin(StaplerRequest req, StaplerResponse rsp) {
+	public void doFinishLogin(StaplerRequest2 req, StaplerResponse2 rsp) {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 		LOG.debug("Finishing CAS login with authentication={}", authentication);
 		req.getSession(); // Force session creation

--- a/src/main/java/org/jenkinsci/plugins/cas/CasSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/CasSecurityRealm.java
@@ -209,6 +209,7 @@ public class CasSecurityRealm extends SecurityRealm {
 				if (authentication instanceof AnonymousAuthenticationToken) {
 					return authentication;
 				} else if ((authentication instanceof UsernamePasswordAuthenticationToken) && Boolean.TRUE.equals(enableRestApi)) {
+					LOG.debug("Authenticating UsernamePasswordAuthenticationToken with CAS REST API");
 					return getApplicationContext().getBean(CasRestAuthenticator.class).authenticate(authentication);
 				} else {
 					throw new BadCredentialsException("Unexpected authentication type: " + authentication);

--- a/src/main/java/org/jenkinsci/plugins/cas/protocols/Cas10Protocol.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/protocols/Cas10Protocol.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.cas.protocols;
 import java.util.Collection;
 
 import org.codehaus.groovy.control.CompilationFailedException;
-import org.jasig.cas.client.validation.TicketValidator;
+import org.apereo.cas.client.validation.TicketValidator;
 import org.jenkinsci.plugins.cas.CasProtocol;
 import org.jenkinsci.plugins.cas.Messages;
 import org.jenkinsci.plugins.cas.validation.Cas10RoleParsingTicketValidator;

--- a/src/main/java/org/jenkinsci/plugins/cas/protocols/Cas20Protocol.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/protocols/Cas20Protocol.java
@@ -4,10 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.jasig.cas.client.validation.Cas20ProxyTicketValidator;
-import org.jasig.cas.client.validation.Cas20ServiceTicketValidator;
-import org.jasig.cas.client.validation.ProxyList;
-import org.jasig.cas.client.validation.TicketValidator;
+import org.apereo.cas.client.validation.Cas20ProxyTicketValidator;
+import org.apereo.cas.client.validation.Cas20ServiceTicketValidator;
+import org.apereo.cas.client.validation.ProxyList;
+import org.apereo.cas.client.validation.TicketValidator;
 import org.jenkinsci.plugins.cas.CasProtocol;
 import org.kohsuke.stapler.DataBoundConstructor;
 

--- a/src/main/java/org/jenkinsci/plugins/cas/protocols/Cas30Protocol.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/protocols/Cas30Protocol.java
@@ -6,12 +6,12 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.jasig.cas.client.validation.Cas30ProxyTicketValidator;
-import org.jasig.cas.client.validation.Cas30ServiceTicketValidator;
-import org.jasig.cas.client.validation.ProxyList;
-import org.jasig.cas.client.validation.TicketValidator;
-import org.jasig.cas.client.validation.json.Cas30JsonProxyTicketValidator;
-import org.jasig.cas.client.validation.json.Cas30JsonServiceTicketValidator;
+import org.apereo.cas.client.validation.Cas30ProxyTicketValidator;
+import org.apereo.cas.client.validation.Cas30ServiceTicketValidator;
+import org.apereo.cas.client.validation.ProxyList;
+import org.apereo.cas.client.validation.TicketValidator;
+import org.apereo.cas.client.validation.json.Cas30JsonProxyTicketValidator;
+import org.apereo.cas.client.validation.json.Cas30JsonServiceTicketValidator;
 import org.jenkinsci.plugins.cas.CasProtocol;
 import org.kohsuke.stapler.DataBoundConstructor;
 

--- a/src/main/java/org/jenkinsci/plugins/cas/protocols/Saml11Protocol.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/protocols/Saml11Protocol.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.cas.protocols;
 
-import org.jasig.cas.client.validation.Saml11TicketValidator;
-import org.jasig.cas.client.validation.TicketValidator;
+import org.apereo.cas.client.validation.Saml11TicketValidator;
+import org.apereo.cas.client.validation.TicketValidator;
 import org.jenkinsci.plugins.cas.CasProtocol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.springframework.security.cas.SamlServiceProperties;

--- a/src/main/java/org/jenkinsci/plugins/cas/spring/CasConfigurationContext.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/spring/CasConfigurationContext.java
@@ -2,11 +2,11 @@ package org.jenkinsci.plugins.cas.spring;
 
 import java.util.Collections;
 
-import org.jasig.cas.client.session.HashMapBackedSessionMappingStorage;
-import org.jasig.cas.client.session.SessionMappingStorage;
-import org.jasig.cas.client.session.SingleSignOutHandler;
-import org.jasig.cas.client.validation.AbstractUrlBasedTicketValidator;
-import org.jasig.cas.client.validation.TicketValidator;
+import org.apereo.cas.client.session.HashMapBackedSessionMappingStorage;
+import org.apereo.cas.client.session.SessionMappingStorage;
+import org.apereo.cas.client.session.SingleSignOutHandler;
+import org.apereo.cas.client.validation.AbstractUrlBasedTicketValidator;
+import org.apereo.cas.client.validation.TicketValidator;
 import org.jenkinsci.plugins.cas.CasProtocol;
 import org.jenkinsci.plugins.cas.CasSecurityRealm;
 import org.jenkinsci.plugins.cas.spring.security.CasRestAuthenticator;
@@ -29,7 +29,7 @@ import org.springframework.security.cas.web.CasAuthenticationFilter;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 
-import hudson.security.ChainedServletFilter;
+import hudson.security.ChainedServletFilter2;
 import hudson.security.HttpSessionContextIntegrationFilter2;
 import hudson.security.SecurityRealm;
 
@@ -158,8 +158,8 @@ public class CasConfigurationContext {
 	}
 
 	@Bean
-	public ChainedServletFilter casFilter(HttpSessionContextIntegrationFilter2 httpSessionContextIntegrationFilter, CasSingleSignOutFilter casSingleSignOutFilter, CasAuthenticationFilter casAuthenticationFilter) {
-		return new ChainedServletFilter(httpSessionContextIntegrationFilter, casSingleSignOutFilter, casAuthenticationFilter);
+	public ChainedServletFilter2 casFilter(HttpSessionContextIntegrationFilter2 httpSessionContextIntegrationFilter, CasSingleSignOutFilter casSingleSignOutFilter, CasAuthenticationFilter casAuthenticationFilter) {
+		return new ChainedServletFilter2(httpSessionContextIntegrationFilter, casSingleSignOutFilter, casAuthenticationFilter);
 	}
 
 	@Bean

--- a/src/main/java/org/jenkinsci/plugins/cas/spring/security/CasRestAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/spring/security/CasRestAuthenticator.java
@@ -10,8 +10,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +21,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.cas.web.CasAuthenticationFilter;
 import org.springframework.security.cas.web.authentication.ServiceAuthenticationDetails;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -37,6 +36,7 @@ import org.springframework.util.Assert;
  */
 public final class CasRestAuthenticator implements InitializingBean, AuthenticationManager {
 
+	private static final String CAS_STATEFUL_IDENTIFIER = "_cas_stateful_";
 	private static final String CAS_V1_TICKETS = "v1/tickets";
 	private static final String ENCODING = "UTF-8";
 	private static final Logger LOG = LoggerFactory.getLogger(CasRestAuthenticator.class);
@@ -221,7 +221,7 @@ public final class CasRestAuthenticator implements InitializingBean, Authenticat
 	}
 
 	private Authentication validateServiceTicket(String serviceTicket) {
-		UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(CasAuthenticationFilter.CAS_STATEFUL_IDENTIFIER, serviceTicket);
+		UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(CAS_STATEFUL_IDENTIFIER, serviceTicket);
 		authRequest.setDetails(authenticationDetailsSource.buildDetails(null));
 		return authenticationManager.authenticate(authRequest);
 	}

--- a/src/main/java/org/jenkinsci/plugins/cas/spring/security/CasSessionFixationProtectionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/spring/security/CasSessionFixationProtectionStrategy.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.plugins.cas.spring.security;
 
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSession;
 
-import org.jasig.cas.client.session.SessionMappingStorage;
+import org.apereo.cas.client.session.SessionMappingStorage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/org/jenkinsci/plugins/cas/spring/security/CasSingleSignOutFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/spring/security/CasSingleSignOutFilter.java
@@ -2,14 +2,14 @@ package org.jenkinsci.plugins.cas.spring.security;
 
 import java.io.IOException;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-import org.jasig.cas.client.session.SingleSignOutHandler;
+import org.apereo.cas.client.session.SingleSignOutHandler;
 import org.springframework.util.Assert;
 import org.springframework.web.filter.GenericFilterBean;
 

--- a/src/main/java/org/jenkinsci/plugins/cas/spring/security/CasUserDetailsService.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/spring/security/CasUserDetailsService.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.jasig.cas.client.validation.Assertion;
+import org.apereo.cas.client.validation.Assertion;
 import org.springframework.security.cas.userdetails.AbstractCasAssertionUserDetailsService;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/src/main/java/org/jenkinsci/plugins/cas/spring/security/DynamicServiceAuthenticationDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/spring/security/DynamicServiceAuthenticationDetails.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.cas.spring.security;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.jenkinsci.plugins.cas.CasSecurityRealm;
 import org.springframework.security.cas.ServiceProperties;

--- a/src/main/java/org/jenkinsci/plugins/cas/spring/security/DynamicServiceAuthenticationDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/spring/security/DynamicServiceAuthenticationDetails.java
@@ -4,7 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import org.jenkinsci.plugins.cas.CasSecurityRealm;
 import org.springframework.security.cas.ServiceProperties;
-import org.springframework.security.cas.web.authentication.ServiceAuthenticationDetails;
+import org.springframework.security.cas.authentication.ServiceAuthenticationDetails;
 
 /**
  * {@code ServiceAuthenticationDetails} implementation that will convert a relative

--- a/src/main/java/org/jenkinsci/plugins/cas/spring/security/DynamicServiceAuthenticationDetailsSource.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/spring/security/DynamicServiceAuthenticationDetailsSource.java
@@ -4,7 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.cas.ServiceProperties;
-import org.springframework.security.cas.web.authentication.ServiceAuthenticationDetails;
+import org.springframework.security.cas.authentication.ServiceAuthenticationDetails;
 
 /**
  * {@code AuthenticationDetailsSource} implementation returning a

--- a/src/main/java/org/jenkinsci/plugins/cas/spring/security/DynamicServiceAuthenticationDetailsSource.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/spring/security/DynamicServiceAuthenticationDetailsSource.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.cas.spring.security;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.cas.ServiceProperties;

--- a/src/main/java/org/jenkinsci/plugins/cas/spring/security/SessionUrlAuthenticationSuccessHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/spring/security/SessionUrlAuthenticationSuccessHandler.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.plugins.cas.spring.security;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.util.StringUtils;

--- a/src/main/java/org/jenkinsci/plugins/cas/spring/security/SessionUrlCasAuthenticationEntryPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/spring/security/SessionUrlCasAuthenticationEntryPoint.java
@@ -1,10 +1,10 @@
 package org.jenkinsci.plugins.cas.spring.security;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
-import org.jasig.cas.client.util.CommonUtils;
+import org.apereo.cas.client.util.WebUtils;
 import org.jenkinsci.plugins.cas.CasSecurityRealm;
 import org.springframework.security.cas.web.CasAuthenticationEntryPoint;
 
@@ -34,7 +34,7 @@ public class SessionUrlCasAuthenticationEntryPoint extends CasAuthenticationEntr
 	@Override
 	protected String createServiceUrl(HttpServletRequest request, HttpServletResponse response) {
 		String serviceUrl = CasSecurityRealm.getServiceUrl(request, getServiceProperties());
-		return CommonUtils.constructServiceUrl(null, response, serviceUrl, null, getServiceProperties().getServiceParameter(), getServiceProperties().getArtifactParameter(), getEncodeServiceUrlWithSessionId());
+		return WebUtils.constructServiceUrl(null, response, serviceUrl, null, getServiceProperties().getServiceParameter(), getServiceProperties().getArtifactParameter(), getEncodeServiceUrlWithSessionId());
 	}
 
 	/**

--- a/src/main/java/org/jenkinsci/plugins/cas/validation/Cas10RoleParsingTicketValidator.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/validation/Cas10RoleParsingTicketValidator.java
@@ -8,12 +8,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.jasig.cas.client.authentication.AttributePrincipal;
-import org.jasig.cas.client.authentication.AttributePrincipalImpl;
-import org.jasig.cas.client.validation.AbstractCasProtocolUrlBasedTicketValidator;
-import org.jasig.cas.client.validation.Assertion;
-import org.jasig.cas.client.validation.AssertionImpl;
-import org.jasig.cas.client.validation.TicketValidationException;
+import org.apereo.cas.client.authentication.AttributePrincipal;
+import org.apereo.cas.client.authentication.AttributePrincipalImpl;
+import org.apereo.cas.client.validation.AbstractCasProtocolUrlBasedTicketValidator;
+import org.apereo.cas.client.validation.Assertion;
+import org.apereo.cas.client.validation.AssertionImpl;
+import org.apereo.cas.client.validation.TicketValidationException;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 
 import groovy.lang.Binding;
@@ -39,7 +39,7 @@ public class Cas10RoleParsingTicketValidator extends AbstractCasProtocolUrlBased
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.jasig.cas.client.validation.AbstractUrlBasedTicketValidator#getUrlSuffix()
+	 * @see org.apereo.cas.client.validation.AbstractUrlBasedTicketValidator#getUrlSuffix()
 	 */
 	protected String getUrlSuffix() {
 		return "validate";
@@ -47,7 +47,7 @@ public class Cas10RoleParsingTicketValidator extends AbstractCasProtocolUrlBased
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.jasig.cas.client.validation.AbstractUrlBasedTicketValidator#parseResponseFromServer(java.lang.String)
+	 * @see org.apereo.cas.client.validation.AbstractUrlBasedTicketValidator#parseResponseFromServer(java.lang.String)
 	 */
 	protected Assertion parseResponseFromServer(final String response) throws TicketValidationException {
 		if (!response.startsWith("yes")) {


### PR DESCRIPTION
Subsumes #16. Gets this plugin to compile with Spring Security 6.x and EE 9, though it appears to have no automated testing and I do not know how to test it manually.