### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,10 @@ THE SOFTWARE.
 	</dependencyManagement>
 	<dependencies>
 		<dependency>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>commons-lang3-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>bouncycastle-api</artifactId>
 		</dependency>

--- a/src/main/java/org/jenkinsci/plugins/cas/CasProtocol.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/CasProtocol.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.client.validation.TicketValidator;
 import org.springframework.security.cas.ServiceProperties;
 

--- a/src/main/java/org/jenkinsci/plugins/cas/CasSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/CasSecurityRealm.java
@@ -12,7 +12,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.client.session.SessionMappingStorage;
 import org.apereo.cas.client.util.CommonUtils;
 import org.jenkinsci.plugins.cas.spring.CasConfigurationContext;

--- a/src/main/java/org/jenkinsci/plugins/cas/protocols/Cas20Protocol.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/protocols/Cas20Protocol.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.cas.protocols;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.client.validation.Cas20ProxyTicketValidator;
 import org.apereo.cas.client.validation.Cas20ServiceTicketValidator;
 import org.apereo.cas.client.validation.ProxyList;

--- a/src/main/java/org/jenkinsci/plugins/cas/protocols/Cas30Protocol.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/protocols/Cas30Protocol.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.client.validation.Cas30ProxyTicketValidator;
 import org.apereo.cas.client.validation.Cas30ServiceTicketValidator;
 import org.apereo.cas.client.validation.ProxyList;


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Lang 3.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed

- Renamed the `org.apache.commons.lang.*` imports to `org.apache.commons.lang3.*` and declared
  `io.jenkins.plugins:commons-lang3-api`.

Kept as a package rename: `stripEnd` has no clean JDK equivalent, and `StringUtils.split` has
separator-character semantics that `String.split` (a regex) does not.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

The `ban-commons-lang-2` enforcer rule was left disabled: it needs parent POM `6.2116.v7501b_67dc517` or newer and this plugin is on `5.6`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact @timja.
